### PR TITLE
Add times-table circle demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!doctype html><html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Times-Table Circle</title><link rel="stylesheet" href="style.css">
+<body>
+<h1>Times-Table Circle</h1>
+<div class="controls">
+  <label>Points n: <input id="n" type="range" min="20" max="800" value="200"> <span id="nVal">200</span></label>
+  <label>Multiplier k: <input id="k" type="range" min="1" max="400" value="2"> <span id="kVal">2</span></label>
+</div>
+<canvas id="canvas" width="900" height="900"></canvas>
+<script src="script.js"></script>
+</body></html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,42 @@
+const canvas=document.getElementById('canvas');
+const ctx=canvas.getContext('2d');
+const nSlider=document.getElementById('n');
+const kSlider=document.getElementById('k');
+const nOut=document.getElementById('nVal');
+const kOut=document.getElementById('kVal');
+
+function fitHiDPI(){
+  const dpr=window.devicePixelRatio||1;
+  const rect=canvas.getBoundingClientRect();
+  canvas.width=Math.round(rect.width*dpr);
+  canvas.height=Math.round(rect.width*dpr);
+  ctx.setTransform(dpr,0,0,dpr,0,0);
+}
+function draw(n,k){
+  fitHiDPI();
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  const dpr=window.devicePixelRatio||1;
+  const cx=canvas.width/dpr/2, cy=cx, pad=20, R=cx-pad;
+  const pts=[];
+  for(let i=0;i<n;i++){
+    const a=2*Math.PI*i/n-Math.PI/2;
+    pts.push([cx+R*Math.cos(a), cy+R*Math.sin(a)]);
+  }
+  ctx.beginPath(); ctx.arc(cx,cy,R,0,Math.PI*2); ctx.strokeStyle='#999'; ctx.lineWidth=1; ctx.stroke();
+  ctx.lineWidth=0.7;
+  for(let i=0;i<n;i++){
+    const j=(i*k)%n;
+    const [x1,y1]=pts[i],[x2,y2]=pts[j];
+    ctx.beginPath(); ctx.moveTo(x1,y1); ctx.lineTo(x2,y2);
+    ctx.strokeStyle=`hsl(${(i*360/n)|0} 70% 45%)`; ctx.stroke();
+  }
+}
+function update(){
+  const n=parseInt(nSlider.value,10);
+  const k=parseInt(kSlider.value,10);
+  nOut.textContent=n; kOut.textContent=k; draw(n,k);
+}
+addEventListener('resize',update);
+nSlider.addEventListener('input',update);
+kSlider.addEventListener('input',update);
+update();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,5 @@
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:16px}
+h1{margin:0 0 12px}
+.controls{display:grid;gap:6px;margin:8px 0 16px}
+label{display:flex;align-items:center;gap:8px}
+#canvas{max-width:95vw;height:auto;border:1px solid #ddd}


### PR DESCRIPTION
## Summary
- Add HTML for times-table circle canvas and controls
- Add CSS styling for layout
- Add JS to draw animated times-table circle visualization

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ce9f2f0008331ab0225ab5309a45e