### PR TITLE
feat: save PNG

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
 <div class="controls">
   <label>Points n: <input id="n" type="range" min="20" max="800" value="200"> <span id="nVal">200</span></label>
   <label>Multiplier k: <input id="k" type="range" min="1" max="400" value="2"> <span id="kVal">2</span></label>
+  <button id="save">Save PNG</button>
 </div>
 <canvas id="canvas" width="900" height="900"></canvas>
 <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@ const nSlider=document.getElementById('n');
 const kSlider=document.getElementById('k');
 const nOut=document.getElementById('nVal');
 const kOut=document.getElementById('kVal');
+const saveBtn=document.getElementById('save');
 
 function fitHiDPI(){
   const dpr=window.devicePixelRatio||1;
@@ -36,7 +37,16 @@ function update(){
   const k=parseInt(kSlider.value,10);
   nOut.textContent=n; kOut.textContent=k; draw(n,k);
 }
+function savePNG(){
+  const name=`times-table-n${nSlider.value}-k${kSlider.value}.png`;
+  const a=document.createElement('a');
+  a.download=name;
+  a.href=canvas.toDataURL('image/png');
+  a.click();
+}
 addEventListener('resize',update);
 nSlider.addEventListener('input',update);
 kSlider.addEventListener('input',update);
+saveBtn.addEventListener('click',savePNG);
+addEventListener('keydown',(e)=>{if(e.key.toLowerCase()==='s')savePNG();});
 update();


### PR DESCRIPTION
## Summary
- add Save PNG button and shortcut
- enable exporting the canvas as a PNG file

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cf81e78488331b589fe132f0966b0