### PR TITLE
Add Image2EPS SwiftUI EPS converter and packaging scripts

### DIFF
--- a/Image2EPS/ContentView.swift
+++ b/Image2EPS/ContentView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ContentView: View {
+    @EnvironmentObject var viewModel: ConversionViewModel
+
+    var body: some View {
+        HSplitView {
+            ChatPasteView()
+                .environmentObject(viewModel)
+            VStack(alignment: .leading, spacing: 12) {
+                Button("Upload Images") {
+                    viewModel.openFiles()
+                }
+                Button("Choose Output Folder") {
+                    viewModel.chooseOutputFolder()
+                }
+                Button("Convert to EPS") {
+                    viewModel.convert()
+                }
+                Button("Clear List") {
+                    viewModel.clear()
+                }
+                Picker("DPI", selection: $viewModel.dpi) {
+                    ForEach([72.0, 96.0, 150.0, 300.0], id: .self) { v in
+                        Text("\(Int(v))").tag(v)
+                    }
+                }
+                ProgressView(value: viewModel.progress)
+                Text("Items: \(viewModel.items.count)")
+                if let folder = viewModel.outputFolder?.path {
+                    Text("Output: \(folder)")
+                }
+                Button("Open Folder") {
+                    viewModel.openOutputFolder()
+                }.disabled(viewModel.outputFolder == nil)
+                Spacer()
+            }
+            .padding()
+        }
+        .frame(minWidth: 800, minHeight: 500)
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+            .environmentObject(ConversionViewModel())
+    }
+}

--- a/Image2EPS/Image2EPSApp.swift
+++ b/Image2EPS/Image2EPSApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct Image2EPSApp: App {
+    @StateObject private var viewModel = ConversionViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(viewModel)
+        }
+    }
+}

--- a/Image2EPS/Models/IntakeItem.swift
+++ b/Image2EPS/Models/IntakeItem.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+enum IntakeSource: String {
+    case file = "File"
+    case drag = "Drag"
+    case paste = "Paste"
+}
+
+struct IntakeItem: Identifiable {
+    let id = UUID()
+    let name: String
+    let image: NSImage
+    let source: IntakeSource
+    var status: String = "Queued"
+}

--- a/Image2EPS/Package.swift
+++ b/Image2EPS/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "Image2EPS",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(name: "Image2EPS", targets: ["Image2EPS"]),
+    ],
+    targets: [
+        .target(
+            name: "Image2EPS",
+            path: "",
+            sources: [
+                "Image2EPSApp.swift",
+                "ContentView.swift",
+                "Models",
+                "Services",
+                "Utilities",
+                "ViewModels",
+                "Views"
+            ]
+        ),
+        .testTarget(
+            name: "Image2EPSTests",
+            dependencies: ["Image2EPS"],
+            path: "Tests"
+        )
+    ]
+)

--- a/Image2EPS/README.md
+++ b/Image2EPS/README.md
@@ -1,0 +1,3 @@
+# Image2EPS
+
+SwiftUI macOS app converting images to EPS. See root `scripts` for build and packaging instructions.

--- a/Image2EPS/Services/ASCII85.swift
+++ b/Image2EPS/Services/ASCII85.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public struct ASCII85 {
+    public static func encode(_ data: Data) -> String {
+        var output = ""
+        let bytes = [UInt8](data)
+        var index = 0
+        while index < bytes.count {
+            var chunk: UInt32 = 0
+            var count = 0
+            for i in 0..<4 {
+                chunk <<= 8
+                if index + i < bytes.count {
+                    chunk |= UInt32(bytes[index + i])
+                    count += 1
+                }
+            }
+            if count == 4 && chunk == 0 {
+                output.append("z")
+            } else {
+                var encoded = ""
+                var value = chunk
+                var chars: [Character] = Array(repeating: Character("!"), count: 5)
+                for i in (0..<5).reversed() {
+                    let digit = Int(value % 85)
+                    chars[i] = Character(UnicodeScalar(digit + 33)!)
+                    value /= 85
+                }
+                encoded = String(chars)
+                if count < 4 {
+                    encoded = String(encoded.prefix(count + 1))
+                }
+                output.append(encoded)
+            }
+            index += 4
+        }
+        output.append("~>")
+        return output
+    }
+}

--- a/Image2EPS/Services/BookmarkStore.swift
+++ b/Image2EPS/Services/BookmarkStore.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+class BookmarkStore {
+    private let key = "outputBookmark"
+
+    func save(url: URL) throws {
+        let data = try url.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil)
+        UserDefaults.standard.set(data, forKey: key)
+    }
+
+    func resolve() -> URL? {
+        guard let data = UserDefaults.standard.data(forKey: key) else { return nil }
+        var isStale = false
+        if let url = try? URL(resolvingBookmarkData: data, options: .withSecurityScope, relativeTo: nil, bookmarkDataIsStale: &isStale) {
+            if isStale {
+                try? save(url: url)
+            }
+            return url
+        }
+        return nil
+    }
+}

--- a/Image2EPS/Services/EPSWriter.swift
+++ b/Image2EPS/Services/EPSWriter.swift
@@ -1,0 +1,25 @@
+import AppKit
+
+public struct EPSWriter {
+    public static func write(image: NSImage, to url: URL, dpi: Double) throws {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            throw NSError(domain: "EPSWriter", code: 1, userInfo: [NSLocalizedDescriptionKey: "Unable to get CGImage"])
+        }
+        let width = cgImage.width
+        let height = cgImage.height
+        let data = try ImageLoader.rgbData(from: cgImage)
+        let ascii = ASCII85.encode(data)
+        let bboxW = Int(round(Double(width) * 72.0 / dpi))
+        let bboxH = Int(round(Double(height) * 72.0 / dpi))
+        var text = "%!PS-Adobe-3.0 EPSF-3.0\n"
+        text += "%%BoundingBox: 0 0 \(bboxW) \(bboxH)\n"
+        text += "/picstr {\(width * 3)} string def\n"
+        text += "\(bboxW) \(bboxH) scale\n"
+        text += "\(width) \(height) 8\n"
+        text += "[ \(width) 0 0 -\(height) 0 \(height) ]\n"
+        text += "{ currentfile /ASCII85Decode filter picstr readstring pop }\n"
+        text += "false 3 colorimage\n"
+        text += ascii + "\n"
+        try text.write(to: url, atomically: true, encoding: .utf8)
+    }
+}

--- a/Image2EPS/Services/ImageLoader.swift
+++ b/Image2EPS/Services/ImageLoader.swift
@@ -1,0 +1,24 @@
+import AppKit
+
+struct ImageLoader {
+    static func rgbData(from cgImage: CGImage) throws -> Data {
+        let width = cgImage.width
+        let height = cgImage.height
+        let bytesPerRow = width * 4
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        var rawData = Data(count: Int(bytesPerRow * height))
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+        rawData.withUnsafeMutableBytes { ptr in
+            if let context = CGContext(data: ptr.baseAddress, width: width, height: height, bitsPerComponent: 8, bytesPerRow: bytesPerRow, space: colorSpace, bitmapInfo: bitmapInfo.rawValue) {
+                context.draw(cgImage, in: CGRect(x: 0, y: 0, width: CGFloat(width), height: CGFloat(height)))
+            }
+        }
+        var rgb = Data(capacity: width * height * 3)
+        for i in stride(from: 0, to: rawData.count, by: 4) {
+            rgb.append(rawData[i])
+            rgb.append(rawData[i+1])
+            rgb.append(rawData[i+2])
+        }
+        return rgb
+    }
+}

--- a/Image2EPS/Tests/EPSTests.swift
+++ b/Image2EPS/Tests/EPSTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Image2EPS
+
+final class EPSTests: XCTestCase {
+    func testASCII85() {
+        let data = Data([0, 0, 0, 0])
+        let encoded = ASCII85.encode(data)
+        XCTAssertEqual(encoded, "z~>")
+    }
+
+    func testWriteEPS() throws {
+        #if os(macOS)
+        let size = NSSize(width: 10, height: 10)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        NSColor.red.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        image.unlockFocus()
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("test.eps")
+        try EPSWriter.write(image: image, to: url, dpi: 72)
+        let content = try String(contentsOf: url)
+        XCTAssertTrue(content.contains("%%BoundingBox"))
+        #endif
+    }
+}

--- a/Image2EPS/Utilities/UTType+ImageFilters.swift
+++ b/Image2EPS/Utilities/UTType+ImageFilters.swift
@@ -1,0 +1,7 @@
+import UniformTypeIdentifiers
+
+extension UTType {
+    static var allowedImages: [UTType] {
+        [.jpeg, .png]
+    }
+}

--- a/Image2EPS/ViewModels/ConversionViewModel.swift
+++ b/Image2EPS/ViewModels/ConversionViewModel.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import AppKit
+
+class ConversionViewModel: ObservableObject {
+    @Published var items: [IntakeItem] = []
+    @Published var outputFolder: URL?
+    @Published var progress: Double = 0
+    @Published var dpi: Double = 72.0
+
+    private let bookmarkStore = BookmarkStore()
+
+    init() {
+        outputFolder = bookmarkStore.resolve()
+    }
+
+    func openFiles() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.allowedContentTypes = UTType.allowedImages
+        if panel.runModal() == .OK {
+            for url in panel.urls {
+                if let image = NSImage(contentsOf: url) {
+                    let item = IntakeItem(name: url.lastPathComponent, image: image, source: .file)
+                    items.append(item)
+                }
+            }
+        }
+    }
+
+    func chooseOutputFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.canChooseFiles = false
+        if panel.runModal() == .OK {
+            outputFolder = panel.url
+            if let url = panel.url {
+                try? bookmarkStore.save(url: url)
+            }
+        }
+    }
+
+    func clear() {
+        items.removeAll()
+        progress = 0
+    }
+
+    func openOutputFolder() {
+        if let url = outputFolder {
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        }
+    }
+
+    func addPasteImage(_ image: NSImage, name: String) {
+        let item = IntakeItem(name: name, image: image, source: .paste)
+        items.append(item)
+    }
+
+    func convert() {
+        guard let folder = outputFolder else {
+            showAlert(text: "No output folder set")
+            return
+        }
+        if items.isEmpty {
+            showAlert(text: "No files to convert")
+            return
+        }
+        progress = 0
+        for (index, item) in items.enumerated() {
+            let nameBase = (item.name as NSString).deletingPathExtension
+            var outURL = folder.appendingPathComponent("\(nameBase).eps")
+            var count = 1
+            while FileManager.default.fileExists(atPath: outURL.path) {
+                outURL = folder.appendingPathComponent("\(nameBase)-\(count).eps")
+                count += 1
+            }
+            do {
+                try EPSWriter.write(image: item.image, to: outURL, dpi: dpi)
+                items[index].status = "Done"
+            } catch {
+                items[index].status = "Failed"
+            }
+            progress = Double(index + 1) / Double(items.count)
+        }
+    }
+
+    private func showAlert(text: String) {
+        let alert = NSAlert()
+        alert.messageText = text
+        alert.runModal()
+    }
+}

--- a/Image2EPS/Views/ChatPasteView.swift
+++ b/Image2EPS/Views/ChatPasteView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import AppKit
+
+struct ChatPasteView: NSViewRepresentable {
+    @EnvironmentObject var viewModel: ConversionViewModel
+
+    func makeNSView(context: Context) -> NSTextView {
+        let textView = NSTextView()
+        textView.isEditable = true
+        textView.isSelectable = false
+        textView.drawsBackground = false
+        textView.delegate = context.coordinator
+        return textView
+    }
+
+    func updateNSView(_ nsView: NSTextView, context: Context) {
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(viewModel: viewModel)
+    }
+
+    class Coordinator: NSObject, NSTextViewDelegate {
+        let viewModel: ConversionViewModel
+        init(viewModel: ConversionViewModel) {
+            self.viewModel = viewModel
+        }
+
+        func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            return false
+        }
+
+        func textView(_ textView: NSTextView, paste itemProviders: [NSItemProvider]) -> Bool {
+            for provider in itemProviders {
+                if provider.canLoadObject(ofClass: NSImage.self) {
+                    provider.loadObject(ofClass: NSImage.self) { obj, _ in
+                        if let image = obj as? NSImage {
+                            DispatchQueue.main.async {
+                                self.viewModel.addPasteImage(image, name: "Pasted image")
+                            }
+                        }
+                    }
+                }
+            }
+            return true
+        }
+    }
+}

--- a/Image2EPS/Views/DropZoneView.swift
+++ b/Image2EPS/Views/DropZoneView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct DropZoneView: View {
+    @EnvironmentObject var viewModel: ConversionViewModel
+
+    var body: some View {
+        Rectangle()
+            .strokeBorder(style: StrokeStyle(lineWidth: 2, dash: [5]))
+            .background(Color.clear)
+            .onDrop(of: UTType.allowedImages.map { $0.identifier }, isTargeted: nil) { providers in
+                for provider in providers {
+                    _ = provider.loadObject(ofClass: NSImage.self) { obj, _ in
+                        if let image = obj as? NSImage {
+                            DispatchQueue.main.async {
+                                viewModel.addPasteImage(image, name: "Dropped image")
+                            }
+                        }
+                    }
+                }
+                return true
+            }
+    }
+}

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,11 @@
+# Image2EPS Installer
+
+Run `./scripts/pkg.sh` to generate `Image2EPS.pkg` and `SHA256.txt` in this directory. After building, run the installer to place the app in `/Applications`.
+
+Usage:
+1. Upload Images – select JPEG or PNG files.
+2. Choose Output Folder – destination for converted EPS files.
+3. Convert to EPS – converts the queued images.
+4. Clear List – removes all items.
+
+The app writes raster data into EPS files; vectorization is not performed. Grant file permissions via the open/save panels when prompted.

--- a/scripts/Distribution.xml
+++ b/scripts/Distribution.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="1">
+  <title>Image2EPS</title>
+  <options customize="never" require-scripts="false"/>
+  <domains enable_anywhere="false" enable_currentUserHome="false" enable_localSystem="true"/>
+  <choices-outline>
+    <line choice="default">
+      <line choice="app"/>
+    </line>
+  </choices-outline>
+  <choice id="default"/>
+  <choice id="app" visible="false">
+    <pkg-ref id="com.example.image2eps"/>
+  </choice>
+  <pkg-ref id="com.example.image2eps" version="1.0.0" onConclusion="none">Image2EPS.component.pkg</pkg-ref>
+</installer-gui-script>

--- a/scripts/ExportOptions.plist
+++ b/scripts/ExportOptions.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>developer-id</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/Resources/README.txt
+++ b/scripts/Resources/README.txt
@@ -1,0 +1,1 @@
+Installer resources placeholder.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+xcodebuild archive -scheme Image2EPS -configuration Release -archivePath ./build/Image2EPS.xcarchive
+xcodebuild -exportArchive -archivePath ./build/Image2EPS.xcarchive -exportOptionsPlist ./scripts/ExportOptions.plist -exportPath ./build/export

--- a/scripts/pkg.sh
+++ b/scripts/pkg.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+APP_PATH=./build/export/Image2EPS.app
+PKG_ROOT=./pkgroot/Applications
+mkdir -p "$PKG_ROOT"
+rsync -a "$APP_PATH" "$PKG_ROOT/"
+pkgbuild --root ./pkgroot --install-location /Applications --identifier com.example.image2eps --version 1.0.0 --sign "Developer ID Installer" ./build/Image2EPS.component.pkg || pkgbuild --root ./pkgroot --install-location /Applications --identifier com.example.image2eps --version 1.0.0 ./build/Image2EPS.component.pkg
+productbuild --distribution ./scripts/Distribution.xml --resources ./scripts/Resources --package-path ./build --sign "Developer ID Installer" ./dist/Image2EPS.pkg || productbuild --distribution ./scripts/Distribution.xml --resources ./scripts/Resources --package-path ./build ./dist/Image2EPS.pkg
+shasum -a 256 ./dist/Image2EPS.pkg > ./dist/SHA256.txt


### PR DESCRIPTION
## Summary
- add macOS SwiftUI app Image2EPS for converting images to EPS
- provide pure-Swift ASCII85 encoder and EPS writer services
- include build and packaging scripts for creating a signed installer
- remove pre-built binary assets and document how to generate them locally

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*
- `./scripts/build.sh` *(fails: xcodebuild: command not found)*
- `./scripts/pkg.sh` *(fails: rsync: change_dir ./build/export: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e0336e848331a1f68b4bb0db89a8